### PR TITLE
Added 'test3' make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 test:
 	python setup.py test
 
+test3:
+	python3 setup.py test
+
 .PHONY:
 	test
+	test3

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,9 @@ Development
 Testing
 -------
 
-The test suite can be run with ``make test``.
+The test suite can be run with ``make test``. This will run the test suite using
+the version used by your local ``python`` command. You can force usage of ``python3``
+by running ``make test3``.
 
 It assumes a running and accessible PostgreSQL server. The connection details
 are deferred to the underlying ``libpq`` implementation, and default values can


### PR DESCRIPTION
This PR adds a make target that uses `python3` to execute tests.
All tests pass for me on Python 3.5.1
